### PR TITLE
Add public API for autologging integration configs

### DIFF
--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -316,6 +316,30 @@ def autologging_integration(name):
     return wrapper
 
 
+def autologging_integration_config(flavor_name, config_key, default_value=None):
+    """
+    Returns a desired config value for a specified autologging integration.
+    Returns `None` if specified `flavor_name` has no recorded configs.
+    If `config_key` is not set on the config object, default vlaue is returned.
+
+    :param flavor_name: An autologging integration flavor name.
+    :param config_key: The key for the desired config value.
+    :param default_value: The default_value to return
+    """
+    config = AUTOLOGGING_INTEGRATIONS.get(flavor_name)
+    if config is not None:
+        return config.get(config_key, default_value)
+
+
+def autologging_is_disabled(flavor_name):
+    """
+    Returns a boolean flag of whether the autologging integration is disabled.
+
+    :param flavor_name: An autologging integration flavor name.
+    """
+    return autologging_integration_config(flavor_name, "disable", False)
+
+
 def _is_testing():
     """
     Indicates whether or not autologging functionality is running in test mode (as determined
@@ -550,10 +574,9 @@ def safe_patch(
         """
         original = gorilla.get_original_attribute(destination, function_name)
 
-        config = AUTOLOGGING_INTEGRATIONS.get(autologging_integration)
         # If the autologging integration associated with this patch is disabled,
         # call the original function and return
-        if config is not None and config.get("disable", False):
+        if autologging_is_disabled(autologging_integration):
             return original(*args, **kwargs)
 
         # Whether or not the original / underlying function has been called during the


### PR DESCRIPTION
Signed-off-by: Mohamad Arabi <mohamad.arabi@databricks.com>

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
