### PR TITLE
Cache artifact repository at client level instead of artifact root at repository level

### DIFF
--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -14,6 +14,9 @@ class ArtifactRepository:
     """
     Abstract artifact repo that defines how to upload (log) and download potentially large
     artifacts from different storage backends.
+
+    Artifact repositories are cached per run ID upon instantiation. It is therefore not
+    recommended to alter the artifact root before a run has terminated.
     """
 
     __metaclass__ = ABCMeta

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -61,7 +61,6 @@ class DatabricksArtifactRepository(ArtifactRepository):
     """
 
     def __init__(self, artifact_uri):
-        print('constructing a databricks artifact repo')
         if not is_valid_dbfs_uri(artifact_uri):
             raise MlflowException(
                 message="DBFS URI must be of the form dbfs:/<path> or "

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -4,7 +4,6 @@ import os
 import posixpath
 import requests
 import uuid
-from collections import OrderedDict
 
 from mlflow.azure.client import put_block, put_block_list
 import mlflow.tracking
@@ -61,9 +60,8 @@ class DatabricksArtifactRepository(ArtifactRepository):
     dbfs:/databricks/mlflow-tracking/<EXP_ID>/<RUN_ID>/
     """
 
-    _artifact_roots_cache = OrderedDict()
-
     def __init__(self, artifact_uri):
+        print('constructing a databricks artifact repo')
         if not is_valid_dbfs_uri(artifact_uri):
             raise MlflowException(
                 message="DBFS URI must be of the form dbfs:/<path> or "
@@ -125,23 +123,9 @@ class DatabricksArtifactRepository(ArtifactRepository):
         return call_endpoint(db_creds, endpoint, method, json_body, response_proto)
 
     def _get_run_artifact_root(self, run_id):
-        # Attempt to fetch the artifact root from a local cache, since artifact locations are
-        # immutable on Databricks
-        cached_root = DatabricksArtifactRepository._artifact_roots_cache.get(run_id)
-        if cached_root is not None:
-            return cached_root
-        else:
-            json_body = message_to_json(GetRun(run_id=run_id))
-            run_response = self._call_endpoint(MlflowService, GetRun, json_body)
-            artifact_root = run_response.run.info.artifact_uri
-
-            # Cache the artifact root to avoid a future network call, removing the oldest
-            # entry in the cache if there are too many elements
-            if len(DatabricksArtifactRepository._artifact_roots_cache) > 1024:
-                DatabricksArtifactRepository.popitem(last=False)
-            DatabricksArtifactRepository._artifact_roots_cache[run_id] = artifact_root
-
-            return artifact_root
+        json_body = message_to_json(GetRun(run_id=run_id))
+        run_response = self._call_endpoint(MlflowService, GetRun, json_body)
+        return run_response.run.info.artifact_uri
 
     def _get_write_credentials(self, run_id, path=None):
         json_body = message_to_json(GetCredentialsForWrite(run_id=run_id, path=path))

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -258,7 +258,6 @@ class TrackingServiceClient(object):
         self.store.record_logged_model(run_id, mlflow_model)
 
     def _get_artifact_repo(self, run_id):
-        # TODO(apurva-koti): ADD CACHING PER REPOSITORY HERE
         # Attempt to fetch the artifact repo from a local cache
         cached_repo = TrackingServiceClient._artifact_repos_cache.get(run_id)
         if cached_repo is not None:

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -22,12 +22,15 @@ from mlflow.store.artifact.artifact_repository_registry import get_artifact_repo
 from mlflow.utils.mlflow_tags import MLFLOW_USER
 from mlflow.utils.string_utils import is_string_type
 from mlflow.utils.uri import add_databricks_profile_info_to_artifact_uri
+from collections import OrderedDict
 
 
 class TrackingServiceClient(object):
     """
     Client of an MLflow Tracking Server that creates and manages experiments and runs.
     """
+
+    _artifact_repos_cache = OrderedDict()
 
     def __init__(self, tracking_uri):
         """
@@ -255,11 +258,24 @@ class TrackingServiceClient(object):
         self.store.record_logged_model(run_id, mlflow_model)
 
     def _get_artifact_repo(self, run_id):
-        run = self.get_run(run_id)
-        artifact_uri = add_databricks_profile_info_to_artifact_uri(
-            run.info.artifact_uri, self.tracking_uri
-        )
-        return get_artifact_repository(artifact_uri)
+        # TODO(apurva-koti): ADD CACHING PER REPOSITORY HERE
+        # Attempt to fetch the artifact repo from a local cache
+        cached_repo = TrackingServiceClient._artifact_repos_cache.get(run_id)
+        if cached_repo is not None:
+            return cached_repo
+        else:
+            run = self.get_run(run_id)
+            artifact_uri = add_databricks_profile_info_to_artifact_uri(
+                run.info.artifact_uri, self.tracking_uri
+            )
+            artifact_repo = get_artifact_repository(artifact_uri)
+            # Cache the artifact repo to avoid a future network call, removing the oldest
+            # entry in the cache if there are too many elements
+            if len(TrackingServiceClient._artifact_repos_cache) > 1024:
+                TrackingServiceClient._artifact_repos_cache.popitem(last=False)
+            TrackingServiceClient._artifact_repos_cache[run_id] = artifact_repo
+            return artifact_repo
+
 
     def log_artifact(self, run_id, local_path, artifact_path=None):
         """


### PR DESCRIPTION
Signed-off-by: Apurva Koti <apurva.koti@databricks.com>

## What changes are proposed in this pull request?
Instead of caching the artifact root URI at the `DatabricksArtifactRepository` level, cache the repository itself at the tracking client level, to discourage across mlflow modification of the artifact root during training.

## How is this patch tested?

Unit tests, though should be added to base branch

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
